### PR TITLE
Fix lots of typos

### DIFF
--- a/doc/src/AdvPLIC.tex
+++ b/doc/src/AdvPLIC.tex
@@ -215,7 +215,7 @@ necessary to partition the application harts for multiple OSes,
 machine-level software would need to prevent direct OS access to the
 supervisor-level interrupt domain and instead provide SBI services
 for controlling PLIC interrupts or, alternatively, emulate the control
-interfaces of separate superivsor-level interrupt domains, one for each
+interfaces of separate supervisor-level interrupt domains, one for each
 OS.
 Note that such emulation might still make use of the PLIC's
 physical supervisor-level interrupt domain, but under the control of
@@ -1425,7 +1425,7 @@ identity, if possible.
 See Section~\ref{sec:AdvPLIC-pendingBits} for exactly when the pending
 bit is cleared by a read of \z{claimi}.
 
-A read from \z{claimi} that returns a value of zero has the simulaneous
+A read from \z{claimi} that returns a value of zero has the simultaneous
 side effect of setting the \z{iforce} register to zero.
 
 Writes to \z{claimi} are ignored.
@@ -1639,7 +1639,7 @@ Even after the PLICs are reconfigured, the hart still cannot be safely
 turned off until it is known no more MSIs are destined for it.
 
 The \z{genmsi} register (Section~\ref{sec:AdvPLIC-reg-genmsi}) exists
-to allow software to determinie when all earlier MSIs have arrived at a
+to allow software to determine when all earlier MSIs have arrived at a
 hart.
 To use \z{genmsi} for this purpose, software can dedicate one external
 interrupt identity at each hart's IMSIC interrupt file solely for PLIC

--- a/doc/src/DuoPLIC.tex
+++ b/doc/src/DuoPLIC.tex
@@ -18,7 +18,7 @@ A proposed standard for the original PLIC is the document
 available as of mid-2021 here:
 \z{https://github.com/{\allowbreak}riscv/{\allowbreak}riscv-plic-spec}.
 However, both free implementations of the PLIC and those of some major
-{\RISCV} vendors such as SiFive have been observed to differ is small
+{\RISCV} vendors such as SiFive have been observed to differ in small
 but significant ways from this document and from each other.
 Some important details of the original PLIC were better documented in
 older versions of

--- a/doc/src/IMSIC.tex
+++ b/doc/src/IMSIC.tex
@@ -216,7 +216,7 @@ These memory-mapped registers are located within a naturally aligned
 \mbox{4-KiB} region (a page) of physical address space that exists for
 the interrupt file, i.e., one page per interrupt file.
 
-The layout of an interupt-file's memory region is:\nopagebreak
+The layout of an interrupt-file's memory region is:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l@{\qquad}l]
 offset    & \ size  & register name \\
 \noalign{\medskip}
@@ -761,7 +761,7 @@ can be accomplished equally by a read of \z{*topei} followed by a write
 of the interrupt identity to the corresponding \z{*clreipnum}, the
 \z{*topei} CSRs could have been made read-only without the special
 behavior defined for writes.
-However, condensing these operations into a single CSR access intead of
+However, condensing these operations into a single CSR access instead of
 two helps to reduce interrupt latency when critical.
 \end{commentary}
 

--- a/doc/src/IOMMU.tex
+++ b/doc/src/IOMMU.tex
@@ -53,7 +53,7 @@ For each I/O device connected to the system through an I/O MMU,
 software can configure at the I/O MMU a \emph{device context}, which
 associates with the device a specific virtual address space and any
 other per-device parameters the I/O MMU may support.
-By giving devices each their own seperate device context at an I/O MMU,
+By giving devices each their own separate device context at an I/O MMU,
 each device can be individually configured for a different software
 master, usually a guest OS or the main (host) OS.
 On every memory access made from a device, hardware indicates to

--- a/doc/src/IPIs.tex
+++ b/doc/src/IPIs.tex
@@ -28,7 +28,7 @@ memory.
 \end{commentary}
 
 The same kind of mechanism (but with a different set of addresses) may
-or may not exist for signalling supervisor-level software interrupts
+or may not exist for signaling supervisor-level software interrupts
 (major code~1) at remote harts as well.
 If not directly supported in this way, then a supervisor-level software
 interrupt is typically sent to another hart through an environment call
@@ -40,9 +40,9 @@ machine-level IPI to the destination hart, where software then sets the
 supervisor-level software interrupt-pending bit (SSIP) in CSR \z{mip}.
 
 When harts have IMSICs, instead of using the Privileged Architecture's
-mechanism for signalling software interrupts at remote harts, an IPI
+mechanism for signaling software interrupts at remote harts, an IPI
 can be sent to a hart by writing to the destination hart's IMSIC, the
-same as a regular message-signalled interrupt (MSI)\@.
+same as a regular message-signaled interrupt (MSI)\@.
 In that case, an incoming IPI appears at the destination hart as an
 \emph{external interrupt} routed through the IMSIC, rather than as a
 software interrupt as before.
@@ -54,7 +54,7 @@ represents an IPI.
 
 If harts do not have IMSICs, then the method specified by the {\RISCV}
 Privileged Architecture is assumed to be used for IPIs, with software
-interrupts signalled at destination harts.
+interrupts signaled at destination harts.
 On the other hand, when harts have IMSICs, the machinery for triggering
 software interrupts at remote harts is redundant with the capabilities
 of the IMSICs, so it is downgraded from a requirement to an option,

--- a/doc/src/IPIs.tex
+++ b/doc/src/IPIs.tex
@@ -46,7 +46,7 @@ same as a regular message-signalled interrupt (MSI)\@.
 In that case, an incoming IPI appears at the destination hart as an
 \emph{external interrupt} routed through the IMSIC, rather than as a
 software interrupt as before.
-However, so long as the same software (e.g.\@ an operating sytem or
+However, so long as the same software (e.g.\@ an operating system or
 machine monitor) is in control at both endpoints of an IPI, source
 and destination, there should be no reason for a destination hart
 to misinterpret the purpose of an incoming external interrupt that

--- a/doc/src/VSLevel.tex
+++ b/doc/src/VSLevel.tex
@@ -59,7 +59,7 @@ registers of this guest interrupt file, just as values of \z{siselect}
 in the same range select registers of the IMSIC's true supervisor-level
 interrupt file.
 The registers of an interrupt file that are accessed indirectly through
-\z{vsiselect} and \z{vireg} are documented in Chapter~\ref{ch:IMSIC}
+\z{vsiselect} and \z{vsireg} are documented in Chapter~\ref{ch:IMSIC}
 on the IMSIC, along with the effects of accessing CSRs \z{vsseteipnum},
 \z{vsclreipnum}, \z{vsseteienum}, \z{vsclreienum}, and \z{vstopei}.
 Because all IMSIC interrupt files act identically, the guest interrupt
@@ -513,7 +513,7 @@ bits 7:0   & IPRIO \\
 All other bits of \z{hvictl} are reserved and read as zeros.
 
 When bit VTI (Virtual Trap Interrupt control) =~1, attempts from
-\mbox{VS-mode} to explictly access CSRs \z{sip}, \z{sie}, or, for RV32
+\mbox{VS-mode} to explicitly access CSRs \z{sip}, \z{sie}, or, for RV32
 only, \z{siph} or \z{sieh}, cause a virtual instruction exception.
 Furthermore, when VTI =~1, a virtual instruction exception is raised
 also for any attempt by the guest to write to a CSR that might

--- a/doc/src/intro.tex
+++ b/doc/src/intro.tex
@@ -53,7 +53,7 @@ Expand the framework for local interrupts at a {\RISCV} hart.
 
 \item
 Optionally allow software to configure the relative priorities of all
-sources of interupts to a {\RISCV} hart (including the standard timer
+sources of interrupts to a {\RISCV} hart (including the standard timer
 and software interrupts, among others), instead of being limited
 just to the ability of a separate interrupt controller to prioritize
 external interrupts only.
@@ -303,7 +303,7 @@ The Advanced Interrupt Architecture adds considerable support
 for \emph{local interrupts} at a hart, whereby a hart essentially
 interrupts itself in response to asynchronous events, usually errors.
 Local interrupts remain contained within a hart (or close to it),
-so like standard {\RISCV} timer and sofware interrupts, they do not
+so like standard {\RISCV} timer and software interrupts, they do not
 pass through an Advanced PLIC or IMSIC.
 
 %-----------------------------------------------------------------------


### PR DESCRIPTION
I noticed a few myself and then ran `aspell -t -c` on everything.
