### PR TITLE
Clarify requirements that AdvPLIC places on IMSICs.

### DIFF
--- a/doc/src/AdvPLIC.tex
+++ b/doc/src/AdvPLIC.tex
@@ -487,10 +487,10 @@ harts.
 A given PLIC implementation may support either or both of these
 delivery modes for each interrupt domain.
 
-If the interrupt domain's harts have IMSICs, the relevant interrupt
-files of those IMSICs must support value \z{0x40000000} for register
-\z{eidelivery}, else setting DM to zero (direct delivery mode) will
-always have the same effect as setting IE to zero.
+If DM is set to zero (direct delivery mode) and the interrupt domain's
+harts have IMSICs then the relevant interrupt files of those IMSICs
+must have \z{eidelivery} set to \z{0x40000000} for the interrupts to
+be connected.
 See Sections \ref{sec:IMSIC-reg-eidelivery}
 and~\ref{sec:AdvPLIC-directMode-intrDelivery}.
 


### PR DESCRIPTION
I found the original sentence to be extremely confusing.  By my parsing, it says that if the harts have IMSICs then the IMSICs must support eidelivery=0x40000000 regardless of whether the PLIC supports DM=0, which seems like an unnecessary requirement.  And if the harts don't have IMSICs then DM=0 acts like IE=0, which doesn't make any sense.

```
If (the interrupt domain's harts have IMSICs) {
  the relevant interrupt files of those IMSICs must support value \z{0x40000000} for register \z{eidelivery}
} else {
  setting DM to zero (direct delivery mode) will always have the same effect as setting IE to zero.
}
```

I believe that this new text captures the actual intent.
