### PR TITLE
Reorganize local and custom major interrupts

### DIFF
--- a/doc/src/MSLevel.tex
+++ b/doc/src/MSLevel.tex
@@ -23,8 +23,8 @@ These minor identities for external interrupts were covered in Chapters
 \ref{ch:IMSIC} and~\ref{ch:AdvPLIC} specifying the IMSIC and
 APLIC components.
 
-The Advanced Interrupt Architecture assigns other major interrupt
-identities in the range 16--63 to additional \emph{local interrupts}
+The Advanced Interrupt Architecture reserves another 24 major
+interrupt identities for additional \emph{local interrupts}
 that arise within or in close proximity to the hart, often for
 reporting errors.
 A mechanism is also defined that allows software to
@@ -38,14 +38,13 @@ interrupts) such that they may mix with the priorities set for external
 interrupts by a PLIC, APLIC, or IMSIC.
 
 %-----------------------------------------------------------------------
-\section{Interrupt allocations and default priorities}
+\section{Defined major interrupts and default priorities}
 \label{sec:majorIntrs}
 
-The base {\RISCV} Privileged Architecture designates major interrupt
-numbers 16 and above as being for platform or custom use.
-The Advanced Interrupt Architecture allocates 24 of these interrupt
-numbers to standardize as local interrupts, and leaves the rest for
-custom use.
+Table~\ref{tab:majorIntrs} lists all the major interrupts
+currently defined for {\RISCV} harts.
+At this time, the only standard major interrupts are those
+specified by the {\RISCV} Privileged Architecture.
 
 \begin{table*}[h!]
 \begin{center}
@@ -55,12 +54,77 @@ Default        &                         & \\
 priority order & Major interrupt numbers & \multicolumn{1}{c|}{Description} \\
 \hline
 \hline
-Highest & 63, 62, 31, 30, 61, 60, & Even numbers are standard local
-                                     interrupts \\
-        & 59, 58, 29, 28, 57, 56, & \ or reserved; odd numbers are
-                                     designated \\
-        & 55, 54, 27, 26, 53, 52, & \ for custom use \\
-        & 51, 50, 25, 24, 49, 48  & \\
+Highest & 11, 3, 7   & Machine interrupts:  external, software, timer \\
+        & \ 9, 1, 5  & Supervisor interrupts:  external, software, timer \\
+        & 12         & Supervisor guest external interrupt \\
+        & 10, 2, 6   & VS interrupts:  external, software, timer \\
+Lowest  & 13         & Counter overflow interrupt \\
+\hline
+\end{tabular}
+\end{center}
+\caption{%
+The standard major interrupt codes, listed in default priority order.
+Currently, all standard codes are defined by
+the {\RISCV} Privileged Architecture.%
+}
+\label{tab:majorIntrs}
+\end{table*}
+
+\begin{table*}[h!]
+\begin{center}
+\begin{tabular}{|c|l|}
+\hline
+                          & \\
+Major interrupt numbers   & \hspace{10mm}Category \\
+\hline
+\hline
+\begin{tabular}{@{}c@{}}
+  \ 0--12 \\
+  13--15 \\
+\end{tabular} &
+    \begin{tabular}{@{}l@{}}
+      Not local interrupts \\
+      Local interrupts \\
+    \end{tabular}
+      $\left\}\begin{tabular}{l@{}}
+        Assigned by the \\
+        \quad Privileged Architecture \\
+      \end{tabular}\right.$ \\
+\hline
+16--23                    & Local interrupts\\
+24--31                    & \em Designated for custom use \\
+32--47                    & Local interrupts \\
+\mbox{\ $\geq \mbox{48}$} & \em Designated for custom use \\
+\hline
+\end{tabular}
+\end{center}
+\caption{Categorization of current and future major interrupts.}
+\label{tab:majorIntrCategories}
+\end{table*}
+
+Of the major interrupts controlled by the Privileged Architecture
+(numbers 0--15), the Advanced Interrupt Architecture categorizes the
+counter overflow interrupt (code~13) as a \emph{local interrupt}.
+It is assumed furthermore that any future definitions for
+reserved interrupt numbers 14 and 15 will also be local interrupts.
+Major interrupt numbers 16--23 and 32--47 are additionally reserved for
+standard local interrupts that other {\RISCV} extensions may define.
+The remaining major interrupts allocated to the Privileged
+Architecture, numbers 0--12, are categorized as not local interrupts.
+Taken altogether, Table~\ref{tab:majorIntrCategories}
+summarizes the Advanced Interrupt Architecture's categorization
+of all major interrupt identities.
+
+\begin{commentary}
+For the standard local interrupts not defined by the
+{\RISCV} Privileged Architecture (numbers 16--23 and 32--47),
+the current plan is to assign default priorities
+in the order shown in this table:
+\begin{center}
+\begin{tabular}{|c|l|l|}
+\hline
+Highest & 47, 23, 46, 45, 22, 44, & \\
+        & 43, 21, 42, 41, 20, 40  & \\
 \cline{2-3}
         & 11, 3, 7   & Machine interrupts:  external, software, timer \\
         & \ 9, 1, 5  & Supervisor interrupts:  external, software, timer \\
@@ -68,53 +132,60 @@ Highest & 63, 62, 31, 30, 61, 60, & Even numbers are standard local
         & 10, 2, 6   & VS interrupts:  external, software, timer \\
         & 13         & Counter overflow interrupt \\
 \cline{2-3}
-        & 47, 46, 23, 22, 45, 44, & Even numbers are standard local
-                                     interrupts \\
-        & 43, 42, 21, 20, 41, 40, & \ or reserved; odd numbers are
-                                     designated \\
-        & 39, 38, 19, 18, 37, 36, & \ for custom use \\
-Lowest  & 35, 34, 17, 16, 33, 32  & \\
+        & 39, 19, 38, 37, 18, 36, & \\
+Lowest  & 35, 17, 34, 33, 16, 32  & \\
 \hline
 \end{tabular}
 \end{center}
-\caption{%
-The default priority order for major interrupts 0--63.
-Interrupt~63 has the highest default priority, and interrupt~32 has the
-lowest default priority.%
-}
-\label{tab:defaultIntrPrios}
-\end{table*}
+Among interrupts 16--23, a higher interrupt number conveys
+higher default priority, and likewise for interrupts 32--47.
+These two groups are interleaved together in the complete order,
+and the Privileged Architecture's standard interrupts, 0--15,
+are inserted into the middle of the sequence.
+This proposed default priority order is arranged so that
+interrupts 0--31 can potentially be an adequate subset on their
+own for \mbox{32-bit} {\RISCV} systems.
 
-Table~\ref{tab:defaultIntrPrios} shows the allocation of major
-interrupt numbers 0--63, listed in default priority order from highest
-to lowest.
-Note that, for interrupts with major identities in the range 16--31, a
-higher interrupt number conveys higher default priority, and likewise
-for major identities in the range 32--63.
-These two groups are interleaved together in the complete order, and
-the Privileged Architecture's standard interrupts, 0--15, are inserted
-into the middle of the sequence.
-
-\begin{commentary}
-The default priority order is arranged so that interrupts 0--31 can
-potentially be an adequate subset on their own for \mbox{32-bit}
-{\RISCV} systems.
+In actuality, future {\RISCV} extensions may or may not stick to
+this plan for the default priority order of interrupts they define.
 \end{commentary}
 
 \begin{commentary}
-If the {\RISCV} Privileged Architecture defines interrupt~0, the
+In addition to the existing major interrupts of
+Table~\ref{tab:majorIntrs}, the following
+local interrupts are tentatively proposed,
+listed in order of decreasing default priority:\nopagebreak
+\begin{displayLinesTable}[l@{\quad}l]
+23 & Bus or system error \\
+45 & Per-core high-power or over-temperature event \\
+43 & High-priority RAS event \\
+\noalign{\smallskip}
+35 & Low-priority RAS event \\
+17 & Debug/trace interrupt \\
+\end{displayLinesTable}
+\noindent
+These local interrupts are expected to be
+specified by other {\RISCV} extensions.
+Be aware, this list is not final and may change
+as the relevant extensions are developed and ratified.
+\emph{RAS} is an abbreviation for \emph{Reliability, Availability, and
+Serviceability}.
+\end{commentary}
+
+\begin{commentary}
+If a future version of the {\RISCV} Privileged Architecture
+defines interrupt~0, the
 Advanced Interrupt Architecture needs it to have a default priority
 lower than certain external interrupts.
 See Sections \ref{sec:mtopi} and~\ref{sec:stopi} on CSRs \z{mtopi} and
 \z{stopi}.
 \end{commentary}
 
-Interrupt numbers 64 and above are all designated for custom use.
-If a hart implements custom interrupts with these numbers, their
+Interrupt numbers 24--31 and 48 and higher
+are all designated for custom use.
+If a hart implements any custom interrupts, their
 positions in the default priority order must be documented for the
 hart.
-Default priority order is standardized by the Advanced Interrupt
-Architecture only for interrupts 0--63.
 
 When a hart supports the arbitrary configuration of interrupt
 priorities by software (described in later sections), the default
@@ -122,62 +193,15 @@ priority order still remains relevant for breaking ties when two
 interrupt sources are assigned the same priority number.
 
 %-----------------------------------------------------------------------
-\section{Defined local interrupts}
-
-The {\RISCV} Privileged Architecture currently defines one local
-interrupt:\nopagebreak
-\begin{displayLinesTable}[l@{\quad}l]
-13 & Counter overflow interrupt\ \ (from extension Sscofpmf) \\
-\end{displayLinesTable}
-The Advanced Interrupt Architecture defines these additional
-local interrupts, listed in order of decreasing default
-priority:\nopagebreak
-\begin{displayLinesTable}[l@{\quad}l]
-30 & Reserved for standard reporting of bus or system errors \\
-58 & Tentatively reserved for per-core high-power/over-temperature events \\
-54 & Reserved for standard high-priority RAS events \\
-\noalign{\bigskip}
-38 & Reserved for standard low-priority RAS events \\
-18 & Debug/trace interrupt \\
-\end{displayLinesTable}
-\emph{RAS} is an abbreviation for \emph{Reliability, Availability, and
-Serviceability}.
-
-\begin{commentary}
-The Advanced Interrupt Architecture reserves local interrupt numbers
-for use by other {\RISCV} standards.
-Complete facilities for managing bus or system errors,
-high-power/over-temperature events, RAS events, or debug/trace
-interrupts are not defined here.
-\end{commentary}
-
-The Advanced Interrupt Architecture does not itself require that all
-local interrupts it defines be implemented.
-A {\RISCV} hart may implement any subset of them, or none of them.
-For whichever ones are implemented, the corresponding bits in CSRs
-\z{mip}/\z{miph} and \z{mie}/\z{mieh} must be writable, and the
-corresponding bits in \z{mideleg}/\z{midelegh} (if those CSRs exist
-because supervisor mode is implemented) may each either be writable or
-be hardwired to zero.
-
-Even when a defined local interrupt is implemented, it is not
-necessarily the case that all events matching the description for that
-interrupt actually cause the local interrupt to be raised.
-For example, a single {\RISCV} system might report bus errors in
-multiple ways, depending on where in the system the error is detected.
-Some bus errors might signal the standard local interrupt (number~30),
-while others are reported as external interrupts, routed through an APLIC
-or IMSIC.
-
-%-----------------------------------------------------------------------
 \section{Interrupts at machine level}
 
-When a hart implements one of the standard local interrupts defined by
-the {\RISCV} Privileged Architecture (number 13, 14, or 15) or by the
-Advanced Interrupt Architecture (an even interrupt number in the
-range 16--62), the corresponding bit position is writable in both
-\z{mip}/\z{miph} and \z{mie}/\z{mieh}.
-An occurrence of the interrupt event causes the interrupt-pending bit
+For whichever standard local interrupts are
+implemented, the corresponding bits in CSRs
+\z{mip}/\z{miph} and \z{mie}/\z{mieh} must be writable, and the
+corresponding bits in \z{mideleg}/\z{midelegh} (if those CSRs exist
+because supervisor mode is implemented) must each either be writable or
+be hardwired to zero.
+An occurrence of a local interrupt event causes the interrupt-pending bit
 in \z{mip}/\z{miph} to be set to one.
 This bit then remains set until cleared by software.
 
@@ -193,7 +217,8 @@ one; and
 
 When multiple interrupt causes are ready to trigger simultaneously, the
 interrupt taken first is determined by priority order, which may be the
-default order specified earlier, or may be a modified order configured
+default order specified in the previous section
+(\ref{sec:majorIntrs}), or may be a modified order configured
 by software.
 
 %- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/doc/src/VSLevel.tex
+++ b/doc/src/VSLevel.tex
@@ -272,29 +272,20 @@ of interrupts for VS level, using hypervisor CSRs \z{hviprio1} and
 and \z{hviprio2h}.
 The subset of major interrupt numbers whose priority may be configured
 in hardware are these:
-\begin{displayLinesTable}[r@{\quad}l]
- 1 & Supervisor software interrupt \\
- 5 & Supervisor timer interrupt \\
-13 & Counter overflow interrupt \\
-14 & (Reserved interrupt) \\
-15 & \quad '' \\
-16 & \quad '' \\
-18 & Debug/trace interrupt \\
-20 & (Reserved interrupt) \\
-22 & \quad '' \\
-24 & \quad '' \\
-26 & \quad '' \\
-28 & \quad '' \\
-30 & (Reserved for standard reporting of bus or system errors) \\
+\begin{displayLinesTable}[c@{\quad}l]
+\ 1    & Supervisor software interrupt \\
+\ 5    & Supervisor timer interrupt \\
+ 13    & Counter overflow interrupt \\
+14--23 & \em Reserved for standard local interrupts \\
 \end{displayLinesTable}
 For interrupts directed to VS level, software-configurable priorities
-are not supported in hardware for custom interrupts or for any
-interrupt numbers higher than~30.
+are not supported in hardware for standard local interrupts
+in the range 32--48.
 
 \begin{commentary}
-If priority configurability is desired for custom interrupts, it can
-be supported by custom CSRs in addition to what is defined here for
-standard interrupts.
+For custom interrupts, priority configurability may be
+supported in hardware by custom CSRs, expanding upon
+\z{hviprio1} and \z{hviprio2} for standard interrupts.
 \end{commentary}
 
 For RV32, registers \z{hviprio1}, \z{hviprio1h}, \z{hviprio2}, and
@@ -302,14 +293,14 @@ For RV32, registers \z{hviprio1}, \z{hviprio1h}, \z{hviprio2}, and
 
 RV32 \z{hviprio1}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
-bits 7:0   & Reserved for priority number for interrupt 0; reads as zero \\
+bits 7:0   & \em Reserved for priority number for interrupt 0; reads as zero \\
 bits 15:8  & Priority number for interrupt 1, supervisor software interrupt \\
-bits 23:16 & Reserved for priority number for interrupt 4; reads as zero \\
+bits 23:16 & \em Reserved for priority number for interrupt 4; reads as zero \\
 bits 31:24 & Priority number for interrupt 5, supervisor timer interrupt \\
 \end{displayLinesTable}
 RV32 \z{hviprio1h}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
-bits 7:0   & Reserved for priority number for interrupt 8; reads as zero \\
+bits 7:0   & \em Reserved for priority number for interrupt 8; reads as zero \\
 bits 15:8  & Priority number for interrupt 13, counter overflow interrupt \\
 bits 23:16 & Priority number for interrupt 14 \\
 bits 31:24 & Priority number for interrupt 15 \\
@@ -317,16 +308,16 @@ bits 31:24 & Priority number for interrupt 15 \\
 RV32 \z{hviprio2}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
 bits 7:0   & Priority number for interrupt 16 \\
-bits 15:8  & Priority number for interrupt 18, debug/trace interrupt \\
-bits 23:16 & Priority number for interrupt 20 \\
-bits 31:24 & Priority number for interrupt 22 \\
+bits 15:8  & Priority number for interrupt 17 \\
+bits 23:16 & Priority number for interrupt 18 \\
+bits 31:24 & Priority number for interrupt 19 \\
 \end{displayLinesTable}
 RV32 \z{hviprio2h}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
-bits 7:0   & Priority number for interrupt 24 \\
-bits 15:8  & Priority number for interrupt 26 \\
-bits 23:16 & Priority number for interrupt 28 \\
-bits 31:24 & Priority number for interrupt 30 \\
+bits 7:0   & Priority number for interrupt 20 \\
+bits 15:8  & Priority number for interrupt 21 \\
+bits 23:16 & Priority number for interrupt 22 \\
+bits 31:24 & Priority number for interrupt 23 \\
 \end{displayLinesTable}
 
 For RV64, registers \z{hviprio1} and \z{hviprio2} are the \mbox{64-bit}
@@ -335,11 +326,11 @@ high-half partners:
 
 RV64 \z{hviprio1}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
-bits 7:0   & Reserved for priority number for interrupt 0; reads as zero \\
+bits 7:0   & \em Reserved for priority number for interrupt 0; reads as zero \\
 bits 15:8  & Priority number for interrupt 1, supervisor software interrupt \\
-bits 23:16 & Reserved for priority number for interrupt 4; reads as zero \\
+bits 23:16 & \em Reserved for priority number for interrupt 4; reads as zero \\
 bits 31:24 & Priority number for interrupt 5, supervisor timer interrupt \\
-bits 39:32 & Reserved for priority number for interrupt 8; reads as zero \\
+bits 39:32 & \em Reserved for priority number for interrupt 8; reads as zero \\
 bits 47:40 & Priority number for interrupt 13, counter overflow interrupt \\
 bits 55:48 & Priority number for interrupt 14 \\
 bits 63:56 & Priority number for interrupt 15 \\
@@ -347,13 +338,13 @@ bits 63:56 & Priority number for interrupt 15 \\
 RV64 \z{hviprio2}:\nopagebreak
 \begin{displayLinesTable}[l@{\quad}l]
 bits 7:0   & Priority number for interrupt 16 \\
-bits 15:8  & Priority number for interrupt 18, debug/trace interrupt \\
-bits 23:16 & Priority number for interrupt 20 \\
-bits 31:24 & Priority number for interrupt 22 \\
-bits 39:32 & Priority number for interrupt 24 \\
-bits 47:40 & Priority number for interrupt 26 \\
-bits 55:48 & Priority number for interrupt 28 \\
-bits 63:56 & Priority number for interrupt 30 \\
+bits 15:8  & Priority number for interrupt 17 \\
+bits 23:16 & Priority number for interrupt 18 \\
+bits 31:24 & Priority number for interrupt 19 \\
+bits 39:32 & Priority number for interrupt 20 \\
+bits 47:40 & Priority number for interrupt 21 \\
+bits 55:48 & Priority number for interrupt 22 \\
+bits 63:56 & Priority number for interrupt 23 \\
 \end{displayLinesTable}
 
 Each priority number in \z{hviprio1}/\z{hviprio1h} and
@@ -531,7 +522,8 @@ to write to \z{stimecmp} or (RV32 only) \z{stimecmph}
 cause a virtual instruction exception when VTI~=~1.
 
 \begin{commentary}
-For standard interrupt numbers in the range 13--63, and for
+For the standard local interrupts
+(major identities 13--23 and 32--47), and for
 software interrupts (SSI), the corresponding interrupt-pending
 bits in \z{vsip}/\z{vsiph} are defined as ``sticky,''
 meaning a guest can clear them only by writing directly

--- a/doc/src/intro.tex
+++ b/doc/src/intro.tex
@@ -317,9 +317,9 @@ interrupt trap.
 Interrupt causes that are standardized by the Privileged Architecture
 have major identities in the range 0--15, while numbers 16 and higher
 are officially available for platform standards or for custom use.
-The Advanced Interrupt Architecture claims further authority over the
-even identity numbers in the range 16--62, leaving the odd numbers in
-that range and all major identities 63 and higher still free for custom
+The Advanced Interrupt Architecture claims further authority over
+identity numbers in the ranges 16--23 and 32--47, leaving numbers in the
+range 24--31 and all major identities 48 and higher still free for custom
 use.
 Table~\ref{tab:interruptIdents} characterizes all major interrupt
 identities with this extension.
@@ -357,10 +357,10 @@ Major identity & Minor identity & \\
 14--15               & -- & \em Reserved by Privileged Architecture \\
 \hline
 \hline
-even numbers, 16--62 & -- & Local interrupts, \emph{or reserved} \\
-odd numbers, 17--63  & -- & \em Designated for custom use \\
-\hline
-$\geq \mbox{64}$     & -- & \em Designated for custom use \\
+16--23         & --       & \em Reserved for standard local interrupts \\
+24--31         & --       & \em Designated for custom use \\
+32--47         & --       & \em Reserved for standard local interrupts \\
+$\geq \mbox{48}$ & --     & \em Designated for custom use \\
 \hline
 \end{tabular}
 \end{center}


### PR DESCRIPTION
And weaken the rules on future major interrupts.

These changes are requested by the RISC-V Architecture Review Committee.