### PR TITLE
Remove CSRs that set/clear an IMSIC interrupt file bit by number

### DIFF
--- a/doc/src/CSRs.tex
+++ b/doc/src/CSRs.tex
@@ -40,19 +40,9 @@ Number & Privilege & Name      & Description \\
 \hline
 \multicolumn{4}{|c|}{Machine-Level Interrupts} \\
 \hline
+\z{0x35C} & MRW & \z{mtopei}   & Machine top external interrupt
+                                  (only with an IMSIC) \\
 \z{0xFB0} & MRO & \z{mtopi}    & Machine top interrupt \\
-\hline
-\multicolumn{4}{|c|}{Machine-Level IMSIC Interface (only with an IMSIC)} \\
-\hline
-\z{0x358} & MRW & \z{mseteipnum}
-                   & Machine set external interrupt-pending bit by number \\
-\z{0x359} & MRW & \z{mclreipnum}
-                   & Machine clear external interrupt-pending bit by number \\
-\z{0x35A} & MRW & \z{mseteienum}
-                   & Machine set external interrupt-enable bit by number \\
-\z{0x35B} & MRW & \z{mclreienum}
-                   & Machine clear external interrupt-enable bit by number \\
-\z{0x35C} & MRW & \z{mtopei}   & Machine top external interrupt \\
 \hline
 \multicolumn{4}{|c|}{Virtual Interrupts for Supervisor Level} \\
 \hline
@@ -128,14 +118,12 @@ instruction exception.
 The contents of the external-interrupts region are documented in
 Chapter~\ref{ch:IMSIC} on the IMSIC.
 
+CSR \z{mtopei} also exists only when an IMSIC is implemented,
+so is documented in Chapter~\ref{ch:IMSIC}
+along with the indirectly accessed IMSIC registers.
+
 CSR \z{mtopi} reports the highest-priority interrupt that is pending
 and enabled for machine level, as specified in Section~\ref{sec:mtopi}.
-
-Five CSRs, \z{mseteipnum}, \z{mclreipnum}, \z{mseteienum},
-\z{mclreienum}, and \z{mtopei}, interact with an IMSIC, so exist only
-when an IMSIC is implemented.
-Like the indirectly accessed IMSIC registers, these CSRs are documented
-in Chapter~\ref{ch:IMSIC}.
 
 When \mbox{S-mode} is implemented, CSRs \z{mvien} and \z{mvip}
 (together with their high-half partners for RV32) support interrupt
@@ -165,19 +153,9 @@ Number & Privilege & Name      & Description \\
 \hline
 \multicolumn{4}{|c|}{Supervisor-Level Interrupts} \\
 \hline
+\z{0x15C} & SRW & \z{stopei}   & Supervisor top external interrupt
+                                  (only with an IMSIC) \\
 \z{0xDB0} & SRO & \z{stopi}    & Supervisor top interrupt \\
-\hline
-\multicolumn{4}{|c|}{Supervisor-Level IMSIC Interface (only with an IMSIC)} \\
-\hline
-\z{0x158} & SRW & \z{sseteipnum}
-                 & Supervisor set external interrupt-pending bit by number \\
-\z{0x159} & SRW & \z{sclreipnum}
-                 & Supervisor clear external interrupt-pending bit by number \\
-\z{0x15A} & SRW & \z{sseteienum}
-                 & Supervisor set external interrupt-enable bit by number \\
-\z{0x15B} & SRW & \z{sclreienum}
-                 & Supervisor clear external interrupt-enable bit by number \\
-\z{0x15C} & SRW & \z{stopei}   & Supervisor top external interrupt \\
 \hline
 \multicolumn{4}{|c|}{%
   Supervisor-Level High-Half CSRs for Interrupts 32--63 (RV32 only)} \\
@@ -229,12 +207,11 @@ when there is no IMSIC, attempts to access \z{sireg} raise an illegal
 instruction exception (unless executing in a virtual machine, covered
 in the next section).
 
+CSR \z{stopei} is described with the IMSIC in Chapter~\ref{ch:IMSIC}.
+
 Register \z{stopi} reports the highest-priority interrupt that
 is pending and enabled for supervisor level, as specified in
 Section~\ref{sec:stopi}.
-The IMSIC CSRs, \z{sseteipnum}, \z{sclreipnum}, \z{sseteienum},
-\z{sclreienum}, and \z{stopei}, are described with the IMSIC in
-Chapter~\ref{ch:IMSIC}.
 
 %-----------------------------------------------------------------------
 \section{Hypervisor and VS CSRs}
@@ -268,19 +245,9 @@ Number & Privilege & Name        & Description \\
 \hline
 \multicolumn{4}{|c|}{VS-Level Interrupts} \\
 \hline
+\z{0x25C} & HRW & \z{vstopei}    & Virtual supervisor top external interrupt
+                                    (only with an IMSIC) \\
 \z{0xEB0} & HRO & \z{vstopi}     & Virtual supervisor top interrupt \\
-\hline
-\multicolumn{4}{|c|}{VS-Level IMSIC Interface (only with an IMSIC)} \\
-\hline
-\z{0x258} & HRW & \z{vsseteipnum}
-                   & VS set external interrupt-pending bit by number \\
-\z{0x259} & HRW & \z{vsclreipnum}
-                   & VS clear external interrupt-pending bit by number \\
-\z{0x25A} & HRW & \z{vsseteienum}
-                   & VS set external interrupt-enable bit by number \\
-\z{0x25B} & HRW & \z{vsclreienum}
-                   & VS clear external interrupt-enable bit by number \\
-\z{0x25C} & HRW & \z{vstopei}    & Virtual supervisor top external interrupt \\
 \hline
 \multicolumn{4}{|c|}{Hypervisor and VS-Level High-Half CSRs (RV32 only)} \\
 \hline
@@ -298,9 +265,9 @@ Number & Privilege & Name        & Description \\
 \label{tab:CSRs-hypervisor}
 \end{table*}
 
-The VS CSRs in the table (\z{vsiselect}, \z{vsireg}, \z{vstopi},
-\z{vsseteipnum}, \z{vsclreipnum}, \z{vsseteienum}, and
-\z{vsclreienum}) all match supervisor CSRs, and substitute for those
+The VS CSRs in the table (\z{vsiselect}, \z{vsireg},
+\z{vstopei}, \z{vstopi}, and, for RV32, \z{vsieh} and \z{vsiph})
+all match supervisor CSRs, and substitute for those
 supervisor CSRs when executing in a virtual machine (in \mbox{VS-mode}
 or \mbox{VU-mode}).
 
@@ -343,10 +310,9 @@ values of \z{vsiselect} designate an inaccessible register.
 
 Along the same lines, when \z{hstatus}.VGEIN is not the number of
 an implemented guest external interrupt, attempts from \mbox{M-mode}
-or \mbox{HS-mode} to access CSRs \z{vsseteipnum}, \z{vsclreipnum},
-\z{vsseteienum}, \z{vsclreienum}, or \z{vstopei} raise an illegal instruction
-exception, and attempts from \mbox{VS-mode} to access \z{sseteipnum},
-\z{sclreipnum}, \z{sseteienum}, \z{sclreienum}, or \z{stopei} raise a
+or \mbox{HS-mode} to access CSR \z{vstopei}
+raise an illegal instruction exception,
+and attempts from \mbox{VS-mode} to access \z{stopei} raise a
 virtual instruction exception.
 
 Aside from the high-half CSR \z{hidelegh}, the hypervisor CSRs added

--- a/doc/src/IMSIC.tex
+++ b/doc/src/IMSIC.tex
@@ -439,29 +439,20 @@ single guest interrupt file, selected by the VGEIN field of CSR
 \z{hstatus}.
 
 For machine level, the relevant CSRs are:\nopagebreak
-\begin{displayLinesTable}[l@{\qquad}l@{\qquad}l]
-\z{miselect} & \z{mseteipnum} & \z{mtopei} \\
-\z{mireg}    & \z{mclreipnum} \\
-             & \z{mseteienum} \\
-             & \z{mclreienum} \\
+\begin{displayLinesTable}
+\z{miselect} \qquad \z{mireg} \qquad \z{mtopei} \\
 \end{displayLinesTable}
 
 When supervisor mode is implemented, the set of supervisor-level CSRs
 matches those of machine level:
-\begin{displayLinesTable}[l@{\qquad}l@{\qquad}l]
-\z{siselect} & \z{sseteipnum} & \z{stopei} \\
-\z{sireg}    & \z{sclreipnum} \\
-             & \z{sseteienum} \\
-             & \z{sclreienum} \\
+\begin{displayLinesTable}
+\z{siselect} \qquad \z{sireg} \qquad \z{stopei} \\
 \end{displayLinesTable}
 
 And when the hypervisor extension is implemented, there is a
 corresponding set of VS CSRs:
-\begin{displayLinesTable}[l@{\qquad}l@{\qquad}l]
-\z{vsiselect} & \z{vsseteipnum} & \z{vstopei} \\
-\z{vsireg}    & \z{vsclreipnum} \\
-              & \z{vsseteienum} \\
-              & \z{vsclreienum} \\
+\begin{displayLinesTable}
+\z{vsiselect} \qquad \z{vsireg} \qquad \z{vstopei} \\
 \end{displayLinesTable}
 
 As explained in Chapter~\ref{ch:CSRs}, registers \z{miselect} and
@@ -508,9 +499,9 @@ Registers \z{eie0} through \z{eie63} contain the enable bits for
 the same interrupt identities, and are collectively called the
 \emph{\texttt{eie} array}.
 
-The indirectly accessed interrupt-file registers, and the other CSRs
-that directly interact with external interrupts (\z{mseteipnum},
-\z{mclreipnum}, etc.), are all documented in more detail in the next
+The indirectly accessed interrupt-file registers
+and CSRs \z{mtopei}, \z{stopei}, and \z{vstopei}
+are all documented in more detail in the next
 two sections.
 
 %-----------------------------------------------------------------------
@@ -635,62 +626,17 @@ to a supported interrupt identity (such as bit~0 of \z{eie0}) are
 read-only zeros.
 
 %-----------------------------------------------------------------------
-\section{CSRs directly affecting an interrupt file}
+\section{%
+Top external interrupt CSRs (\zSafe{mtopei}, \zSafe{stopei}, \zSafe{vstopei})%
+}
 
-Several new machine-level CSRs interact directly with an IMSIC's
-machine-level interrupt file:  \z{mseteipnum}, \z{mclreipnum},
-\z{mseteienum}, \z{mclreienum}, and \z{mtopei}.
-If supervisor mode is implemented, there are several matching
-supervisor CSRs that likewise interact with the supervisor-level
-interrupt file:  \z{sseteipnum}, \z{sclreipnum}, \z{sseteienum},
-\z{sclreienum}, and \z{stopei}.
+CSR \z{mtopei} interacts directly with
+an IMSIC's machine-level interrupt file.
+If supervisor mode is implemented, CSR \z{stopei} interacts
+directly with the supervisor-level interrupt file.
 And if the hypervisor extension is implemented and field VGEIN of
 \z{hstatus} is the number of an implemented guest interrupt file,
-several VS CSRs interact with the chosen guest interrupt file:
-\z{vsseteipnum}, \z{vsclreipnum}, \z{vsseteienum}, \z{vsclreienum},
-and \z{vstopei}.
-These CSRs are documented by function below:
-
-%- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-\subsection{%
-Set/clear external interrupt-pending bit by number
-(\zSafe{*seteipnum} and \zSafe{*clreipnum})%
-}
-
-If $i$ is an implemented interrupt identity number in the respective
-interrupt file, writing value $i$ to a \emph{\texttt{*seteipnum} CSR}
-(\z{mseteipnum}, \z{sseteipnum}, or \z{vsseteipnum}) causes the pending
-bit for interrupt~$i$ to be set to one in the interrupt file, while
-writing $i$ to a \emph{\texttt{*clreipnum} CSR} (\z{mclreipnum},
-\z{sclreipnum}, or \z{vsclreipnum}) causes the pending bit for
-interrupt~$i$ to be cleared in the interrupt file.
-A write to a \z{*seteipnum} or \z{*clreipnum} CSR is ignored if the
-value written is not an implemented interrupt identity number for the
-respective interrupt file.
-
-A read of a \z{*seteipnum} or \z{*clreipnum} CSR always returns zero.
-
-%- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-\subsection{%
-Set/clear external interrupt-enable bit by number
-(\zSafe{*seteienum} and \zSafe{*clreienum})%
-}
-
-If $i$ is an implemented interrupt identity number in the respective
-interrupt file, writing value $i$ to a \emph{\texttt{*seteienum} CSR}
-(\z{mseteienum}, \z{sseteienum}, or \z{vsseteienum}) causes the enable
-bit for interrupt~$i$ to be set to one in the interrupt file, while
-writing $i$ to a \emph{\texttt{*clreienum} CSR} (\z{mclreienum},
-\z{sclreienum}, or \z{vsclreienum}) causes the enable bit for
-interrupt~$i$ to be cleared in the interrupt file.
-A write to a \z{*seteienum} or \z{*clreienum} CSR is ignored if the
-value written is not an implemented interrupt identity number for the
-respective interrupt file.
-
-A read of a \z{*seteienum} or \z{*clreienum} CSR always returns zero.
-
-%- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-\subsection{Top external interrupt (\zSafe{*topei})}
+\z{vstopei} interacts with the chosen guest interrupt file.
 
 The value of a \emph{\texttt{*topei} CSR} (\z{mtopei}, \z{stopei}, or
 \z{vstopei}) indicates the interrupt file's current highest-priority
@@ -751,18 +697,9 @@ lost.
 
 If it is necessary first to read a \z{*topei} CSR and then subsequently
 claim the interrupt as a separate step, the claim can be safely done by
-writing the interrupt identity to the corresponding \z{*clreipnum} CSR,
+clearing the pending bit in the \z{eip} array
+via \z{*siselect} and \z{*sireg},
 instead of writing to \z{*topei}.
-\end{commentary}
-
-\begin{commentary}
-Because the effect of a combined read-and-write of a \z{*topei} CSR
-can be accomplished equally by a read of \z{*topei} followed by a write
-of the interrupt identity to the corresponding \z{*clreipnum}, the
-\z{*topei} CSRs could have been made read-only without the special
-behavior defined for writes.
-However, condensing these operations into a single CSR access instead of
-two helps to reduce interrupt latency when critical.
 \end{commentary}
 
 %-----------------------------------------------------------------------

--- a/doc/src/VSLevel.tex
+++ b/doc/src/VSLevel.tex
@@ -19,8 +19,7 @@ supervisor-level interrupts.
 
 As introduced in Chapter~\ref{ch:CSRs}, several hypervisor and VS CSRs
 are added:  \z{hvien}, \z{hvictl}, \z{hviprio1}, \z{hviprio2},
-\z{vsiselect}, \z{vsireg}, \z{vstopi}, \z{vsseteipnum},
-\z{vsclreipnum}, \z{vsseteienum}, \z{vsclreienum}, and \z{vstopei}.
+\z{vsiselect}, \z{vsireg}, \z{vstopei}, and \z{vstopi}.
 For RV32, the following ``high-half'' CSR partners are also added:
 \z{hidelegh}, \z{hvienh}, \z{hviph}, \z{hviprio1h}, \z{hviprio2h},
 \z{vsiph}, and \z{vsieh}.
@@ -60,11 +59,9 @@ in the same range select registers of the IMSIC's true supervisor-level
 interrupt file.
 The registers of an interrupt file that are accessed indirectly through
 \z{vsiselect} and \z{vsireg} are documented in Chapter~\ref{ch:IMSIC}
-on the IMSIC, along with the effects of accessing CSRs \z{vsseteipnum},
-\z{vsclreipnum}, \z{vsseteienum}, \z{vsclreienum}, and \z{vstopei}.
+on the IMSIC, along with IMSIC-only CSR \z{vstopei}.
 Because all IMSIC interrupt files act identically, the guest interrupt
 file that a virtual hart accesses through CSRs \z{siselect}, \z{sireg},
-\z{sseteipnum}, \z{sclreipnum}, \z{sseteienum}, \z{sclreienum},
 and \z{stopei} is indistinguishable from a true supervisor-level
 interrupt file as seen from \mbox{S-mode} (or \mbox{HS-mode}).
 
@@ -91,13 +88,11 @@ When a virtual hart appears to have an IMSIC because a guest interrupt
 file is assigned to it, all external interrupts, real or emulated,
 destined for the virtual hart must go through this perceived IMSIC.
 A hypervisor can easily inject an emulated external interrupt into the
-guest interrupt file selected by \z{hstatus}.VGEIN simply by writing to
-CSR \z{vsseteipnum}.
-When a virtual hart has a guest interrupt file, there is no reason
-for a hypervisor to set bit VSEIP in CSR \z{hvip}, as this method
-of asserting a VS-level external interrupt is more trouble than just
-writing to \z{vsseteipnum} to set a specific interrupt-pending bit in
-the guest interrupt file.
+guest interrupt file selected by \z{hstatus}.VGEIN
+by setting a bit in the interrupt-pending array
+indirectly accessed through \z{vsiselect} and \z{vsireg}.
+When a virtual hart has a guest interrupt file, a hypervisor
+is not normally expected to set bit VSEIP in CSR \z{hvip}.
 
 In the special case that an emulated APLIC for a virtual
 machine has a wired interrupt source that equates to an actual


### PR DESCRIPTION
These changes are requested by the RISC-V Architecture Review Committee.