### PR TITLE
Remove term 'master', replace with appropriate term

### DIFF
--- a/doc/src/AdvPLIC.tex
+++ b/doc/src/AdvPLIC.tex
@@ -20,7 +20,7 @@ But even in machines where harts have IMSICs and most interrupts are
 communicated via MSIs, it is not unusual for some device interrupts
 still to be signaled by dedicated wires.
 In particular, for devices (or device controllers) that do not
-otherwise need to be bus masters in the system, the cost of supporting
+otherwise need to be bus controllers in the system, the cost of supporting
 MSIs is especially high, so wired interrupts are a frugal alternative.
 Wired interrupts also continue to be universally supported by all
 current computer platforms, unlike MSIs, making another reason for many
@@ -189,7 +189,7 @@ application harts, even at machine level.
 \caption{%
 A {\RISCV} system that extends the example of
 Figure~\ref{fig:AdvPLIC-ex-2Domains} with a fifth \mbox{M-mode}-only
-``master'' hart, with a separate machine-level interrupt domain above
+``main'' hart, with a separate machine-level interrupt domain above
 the other domains.%
 }
 \label{fig:AdvPLIC-ex-3Domains}

--- a/doc/src/IOMMU.tex
+++ b/doc/src/IOMMU.tex
@@ -38,7 +38,7 @@ processes MSIs directed to virtual machines.
 Most other functions and details of an \mbox{IOMMU} are beyond the scope of
 this standard, and must be specified elsewhere.
 
-If a single physical I/O device can be subdivided for multiple masters,
+If a single physical I/O device can be subdivided for multiple controllers,
 each sub-device is referred to here as one device.
 
 %-----------------------------------------------------------------------
@@ -55,7 +55,7 @@ associates with the device a specific virtual address space and any
 other per-device parameters the \mbox{IOMMU} may support.
 By giving devices each their own separate device context at an \mbox{IOMMU},
 each device can be individually configured for a different software
-master, usually a guest OS or the main (host) OS.
+controller, usually a guest OS or the main (host) OS.
 On every memory access made from a device, hardware indicates to
 the \mbox{IOMMU} the originating device by some form of unique device
 identifier, which the \mbox{IOMMU} uses to locate the appropriate device


### PR DESCRIPTION
I chose 'main' and 'controller' as replacements for the term 'master' as
the situation warranted.

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>