### PR TITLE
Make clear that the draft chapters won't change ratified parts

### DIFF
--- a/doc/src/preface.tex
+++ b/doc/src/preface.tex
@@ -54,5 +54,9 @@ A separate standard is being developed for IOMMUs in {\RISCV} systems.
 Chapter~\ref{ch:IOMMU} about an IOMMU's support for MSIs
 (message-signaled interrupts) is expected to be finalized
 only in conjunction with the full {\RISCV} IOMMU specification.
+
+\item
+Any advancement of these chapters will be constrained such that it does
+not change the ratified parts of this document (e.g. by adding new CSRs).
 \end{itemize}
 


### PR DESCRIPTION
There were concerns that the draft chapters of this specification might have an impact on the ratified parts once they advance. Let's make it clear that this is not the case.